### PR TITLE
feat: added fields to profile model

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -636,6 +636,7 @@ github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4O
 github.com/prometheus/procfs v0.3.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.6.0 h1:mxy4L2jP6qMonqmq+aTtOx1ifVWUgG/TAmntgbh3xv4=
 github.com/prometheus/procfs v0.6.0/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
+github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
 github.com/prometheus/procfs v0.7.3/go.mod h1:cz+aTbrPOrUb4q7XlbU9ygM+/jj0fzG6c1xBZuNvfVA=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/pseudomuto/protoc-gen-doc v1.3.2/go.mod h1:y5+P6n3iGrbKG+9O04V5ld71in3v/bX88wUwgt+U8EA=

--- a/models/profile_model.go
+++ b/models/profile_model.go
@@ -1,14 +1,32 @@
 package models
 
+type CertificateModel struct {
+	IsCertified         bool   `bson:"isCertified" json:"isCertified"`
+	CertificationId     string `bson:"certificateId" json:"certificateId"`
+	CertificationName   string `bson:"certificateName" json:"certificateName"`
+	CertificationAgency string `bson:"certificationAgency" json:"certificationAgency"`
+}
+type Location struct {
+	Lat  float64 `bson:"lat" json:"lat"`
+	Long float64 `bson:"long" json:"long"`
+}
+
 type ProfileModel struct {
-	LoginId           string                 `bson:"_id" json:"loginId"`
-	Name              string                 `bson:"name,omitempty" json:"name"`
-	PhotoUrl          string                 `bson:"photoUrl" json:"photoUrl"`
-	Gender            string                 `bson:"gender" json:"gender" copier:"-"`
-	IsVerified        bool                   `bson:"isVerified" json:"isVerified"`
-	PreferredLanguage string                 `bson:"preferredLanguage" json:"preferredLanguage"`
-	MetadataMap       map[string]interface{} `bson:"metadata"`
-	CreatedOn         int64                  `bson:"createdOn,omitempty" json:"createdOn"`
+	LoginId                  string                 `bson:"_id" json:"loginId"`
+	Name                     string                 `bson:"name,omitempty" json:"name"`
+	PhotoUrl                 string                 `bson:"photoUrl" json:"photoUrl"`
+	Addresses                map[string]interface{} `bson:"addresses" json:"addresses"`
+	Location                 Location               `bson:"location" json:"location"`
+	FarmingType              string                 `bson:"farmingType" json:"farmingType"`
+	Bio                      string                 `bson:"bio" json:"bio"`
+	Crops                    []string               `bson:"crops" json:"crops"`
+	YearsSinceOrganicFarming int                    `bson:"yearsSinceOrganicFarming" json:"yearsSinceOrganicFarming"`
+	Gender                   string                 `bson:"gender" json:"gender" copier:"-"`
+	IsVerified               bool                   `bson:"isVerified" json:"isVerified"`
+	PreferredLanguage        string                 `bson:"preferredLanguage" json:"preferredLanguage"`
+	MetadataMap              map[string]interface{} `bson:"metadata"`
+	CertificationDetails     CertificateModel       `bson:"certificationDetails" json:"certificationDetails"`
+	CreatedOn                int64                  `bson:"createdOn,omitempty" json:"createdOn"`
 }
 
 func (m *ProfileModel) Id() string {


### PR DESCRIPTION
Added following fields to the profile model:

1. bio : string type
2. farmingType: a string 
3. certificationDetails: a message with fields isCertified, certificationName, certificationId, certificationAgency
4. yearsSinceOrganicFarming: type int
5. addresses: a map of string and interface
6. crops: array of string
7. Location: to store location details when the geocoding api is implemented
[Profiletest.webm](https://github.com/Kotlang/authGo/assets/106036571/01ae6c7c-4d5f-48b3-961c-0a97781d081b)

